### PR TITLE
Add RSS feed from Enschede

### DIFF
--- a/libraries/FeedWriter/ATOM.php
+++ b/libraries/FeedWriter/ATOM.php
@@ -1,0 +1,38 @@
+<?php
+namespace FeedWriter;
+
+/*
+ * Copyright (C) 2012 Michael Bemmerl <mail@mx-server.de>
+ *
+ * This file is part of the "Universal Feed Writer" project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Wrapper for creating ATOM feeds
+ *
+ * @package     UniversalFeedWriter
+ */
+class ATOM extends Feed
+{
+    /**
+    * {@inheritdoc}
+    */
+    public function __construct()
+    {
+        parent::__construct(Feed::ATOM);
+    }
+
+}

--- a/libraries/FeedWriter/COPYING
+++ b/libraries/FeedWriter/COPYING
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/libraries/FeedWriter/Feed.php
+++ b/libraries/FeedWriter/Feed.php
@@ -1,0 +1,883 @@
+<?php
+namespace FeedWriter;
+
+use \DateTime;
+
+/*
+ * Copyright (C) 2008 Anis uddin Ahmad <anisniit@gmail.com>
+ * Copyright (C) 2010-2014 Michael Bemmerl <mail@mx-server.de>
+ *
+ * This file is part of the "Universal Feed Writer" project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// RSS 0.90  Officially obsoleted by 1.0
+// RSS 0.91, 0.92, 0.93 and 0.94  Officially obsoleted by 2.0
+// So, define constants for RSS 1.0, RSS 2.0 and ATOM
+
+/**
+ * Universal Feed Writer class
+ *
+ * Generate RSS 1.0, RSS2.0 and ATOM Feeds
+ *
+ * @package     UniversalFeedWriter
+ * @author      Anis uddin Ahmad <anisniit@gmail.com>
+ * @link        http://www.ajaxray.com/projects/rss
+ */
+abstract class Feed
+{
+    const RSS1 = 'RSS 1.0';
+    const RSS2 = 'RSS 2.0';
+    const ATOM = 'ATOM';
+
+    /**
+    * Collection of all channel elements
+    */
+    private $channels      = array();
+
+    /**
+    * Collection of items as object of \FeedWriter\Item class.
+    */
+    private $items         = array();
+
+    /**
+    * Store some other version wise data
+    */
+    private $data          = array();
+
+    /**
+    * The tag names which have to encoded as CDATA
+    */
+    private $CDATAEncoding = array();
+
+    /**
+    * Collection of XML namespaces
+    */
+    private $namespaces    = array();
+
+    /**
+    * Contains the format of this feed.
+    */
+    private $version   = null;
+    
+    /**
+    * Constructor
+    *
+    * If no version is given, a feed in RSS 2.0 format will be generated.
+    *
+    * @param    constant  the version constant (RSS1/RSS2/ATOM).
+    */
+    protected function __construct($version = Feed::RSS2)
+    {
+        $this->version = $version;
+
+        // Setting default encoding
+        $this->encoding = 'utf-8';
+
+        // Setting default value for essential channel elements
+        $this->channels['title'] = $version . ' Feed';
+        $this->channels['link']  = 'http://www.ajaxray.com/blog';
+
+        // Add some default XML namespaces
+        $this->namespaces['content'] = 'http://purl.org/rss/1.0/modules/content/';
+        $this->namespaces['wfw'] = 'http://wellformedweb.org/CommentAPI/';
+        $this->namespaces['atom'] = 'http://www.w3.org/2005/Atom';
+        $this->namespaces['rdf'] = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
+        $this->namespaces['rss1'] = 'http://purl.org/rss/1.0/';
+        $this->namespaces['dc'] = 'http://purl.org/dc/elements/1.1/';
+        $this->namespaces['sy'] = 'http://purl.org/rss/1.0/modules/syndication/';
+
+        // Tag names to encode in CDATA
+        $this->addCDATAEncoding(array('description', 'content:encoded', 'summary'));
+    }
+
+    // Start # public functions ---------------------------------------------
+    
+    /**
+    * Set the URLs for feed pagination.
+    *
+    * See RFC 5005, chapter 3. At least one page URL must be specified.
+    *
+    * @param   string  The URL to the next page of this feed. Optional.
+    * @param   string  The URL to the previous page of this feed. Optional.
+    * @param   string  The URL to the first page of this feed. Optional.
+    * @param   string  The URL to the last page of this feed. Optional.
+    * @link    http://tools.ietf.org/html/rfc5005#section-3
+    * @return  self
+     */
+    public function setPagination($nextURL = null, $previousURL = null, $firstURL = null, $lastURL = null)
+    {
+        if (empty($nextURL) && empty($previousURL) && empty($firstURL) && empty($lastURL))
+            die('At least one URL must be specified for pagination to work.');
+
+        if (!empty($nextURL))
+            $this->setAtomLink($nextURL, 'next');
+
+        if (!empty($previousURL))
+            $this->setAtomLink($previousURL, 'previous');
+
+        if (!empty($firstURL))
+            $this->setAtomLink($firstURL, 'first');
+
+        if (!empty($lastURL))
+            $this->setAtomLink($lastURL, 'last');
+
+        return $this;
+    }
+
+    /**
+    * Add a channel element indicating the program used to generate the feed.
+    *
+    * @return   self
+    */
+    public function addGenerator()
+    {
+        if ($this->version == Feed::ATOM)
+            $this->setChannelElement('atom:generator', 'FeedWriter', array('uri' => 'https://github.com/mibe/FeedWriter'));
+        else if ($this->version == Feed::RSS2)
+            $this->setChannelElement('generator', 'FeedWriter');
+        else
+            die('The generator element is not supported in RSS1 feeds.');
+
+        return $this;
+    }
+
+    /**
+    * Add a XML namespace to the internal list of namespaces. After that,
+    * custom channel elements can be used properly to generate a valid feed.
+    *
+    * @access   public
+    * @param    string  namespace prefix
+    * @param    string  namespace name (URI)
+    * @return   self
+    * @link     http://www.w3.org/TR/REC-xml-names/
+    */
+    public function addNamespace($prefix, $uri)
+    {
+        $this->namespaces[$prefix] = $uri;
+
+        return $this;
+    }
+
+    /**
+    * Add a channel element to the feed.
+    *
+    * @access   public
+    * @param    string  name of the channel tag
+    * @param    string  content of the channel tag
+    * @param    array   array of element attributes with attribute name as array key
+    * @param    bool    TRUE if this element can appear multiple times
+    * @return   self
+    */
+    public function setChannelElement($elementName, $content, $attributes = null, $multiple = false)
+    {
+        $entity['content'] = $content;
+        $entity['attributes'] = $attributes;
+
+        if ($multiple === TRUE)
+            $this->channels[$elementName][] = $entity;
+        else
+            $this->channels[$elementName] = $entity;
+
+        return $this;
+    }
+
+    /**
+    * Set multiple channel elements from an array. Array elements
+    * should be 'channelName' => 'channelContent' format.
+    *
+    * @access   public
+    * @param    array   array of channels
+    * @return   self
+    */
+    public function setChannelElementsFromArray($elementArray)
+    {
+        if (!is_array($elementArray))
+            return;
+
+        foreach ($elementArray as $elementName => $content) {
+            $this->setChannelElement($elementName, $content);
+        }
+
+        return $this;
+    }
+
+    /**
+    * Get the appropriate MIME type string for the current feed.
+    *
+    * @access   public
+    * @return   string  The MIME type string.
+    */
+    public function getMIMEType()
+    {
+        switch ($this->version) {
+            case Feed::RSS2 : $mimeType = "application/rss+xml";
+                break;
+            case Feed::RSS1 : $mimeType = "application/rdf+xml";
+                break;
+            case Feed::ATOM : $mimeType = "application/atom+xml";
+                break;
+            default : $mimeType = "text/xml";
+        }
+
+        return $mimeType;
+    }
+
+    /**
+    * Print the actual RSS/ATOM file
+    *
+    * Sets a Content-Type header and echoes the contents of the feed.
+    * Should only be used in situations where direct output is desired;
+    * if you need to pass a string around, use generateFeed() instead.
+    *
+    * @access   public
+    * @param    bool    FALSE if the specific feed media type should be sent.
+    * @return   void
+    */
+    public function printFeed($useGenericContentType = false)
+    {
+        $contentType = "text/xml";
+
+        if (!$useGenericContentType) {
+            $contentType = $this->getMIMEType();
+        }
+
+        header("Content-Type: " . $contentType);
+        echo $this->generateFeed();
+    }
+
+    /**
+    * Generate the feed.
+    *
+    * @access   public
+    * @return   string  The complete feed XML.
+    */
+    public function generateFeed()
+    {
+        return $this->makeHeader()
+            . $this->makeChannels()
+            . $this->makeItems()
+            . $this->makeFooter();
+    }
+
+    /**
+    * Create a new Item.
+    *
+    * @access   public
+    * @return   Item  instance of Item class
+    */
+    public function createNewItem()
+    {
+        $Item = new Item($this->version);
+
+        return $Item;
+    }
+
+    /**
+     * Add a properties to be CDATA encoded
+     *
+     * @access  public
+     * @param   array   An array of properties that are merged into the list of properties should be encoded as CDATA
+     * @return  self
+     */
+    public function addCDATAEncoding(Array $property_list)
+    {
+        $this->CDATAEncoding = array_merge($this->CDATAEncoding, $property_list);
+
+        return $this;
+    }
+
+    /**
+     * Get list of CDATA encoded properties
+     *
+     * @access  public
+     * @return  array   Return an array of CDATA properties that are to be encoded as CDATA
+     */
+    public function getCDATAEncoding()
+    {
+        return $this->CDATAEncoding;
+    }
+
+    /**
+    * Add a FeedItem to the main class
+    *
+    * @access   public
+    * @param    Item    instance of Item class
+    * @return   self
+    */
+    public function addItem(Item $feedItem)
+    {
+        if ($feedItem->getVersion() != $this->version)
+            die('Feed type mismatch: This instance can handle ' . $this->version . ' feeds only, but item with type ' . $feedItem->getVersion() . ' given.');
+
+        $this->items[] = $feedItem;
+
+        return $this;
+    }
+
+    // Wrapper functions -------------------------------------------------------------------
+
+    /**
+    * Set the 'encoding' attribute in the XML prolog.
+    *
+    * @access   public
+    * @param    string  value of 'encoding' attribute
+    * @return   self
+    */
+    public function setEncoding($encoding)
+    {
+        $this->encoding = $encoding;
+
+        return $this;
+    }
+
+    /**
+    * Set the 'title' channel element
+    *
+    * @access   public
+    * @param    string  value of 'title' channel tag
+    * @return   self
+    */
+    public function setTitle($title)
+    {
+        return $this->setChannelElement('title', $title);
+    }
+
+    /**
+    * Set the date when the ATOM feed was lastly updated.
+    *
+    * This adds the 'updated' element to the feed. The value of the date parameter
+    * can be either an instance of the DateTime class, an integer containing a UNIX
+    * timestamp or a string which is parseable by PHP's 'strtotime' function.
+    *
+    * Not supported in RSS1 feeds.
+    *
+    * @access   public
+    * @param    DateTime|int|string  Date which should be used.
+    * @return   self
+    */
+    public function setDate($date)
+    {
+        if ($this->version == Feed::RSS1)
+            die('The publication date is not supported in RSS1 feeds.');
+
+        // The feeds have different date formats.
+        $format = $this->version == Feed::ATOM ? \DATE_ATOM : \DATE_RSS;
+
+        if ($date instanceof DateTime)
+            $date = $date->format($format);
+        else if(is_numeric($date) && $date >= 0)
+            $date = date($format, $date);
+        else if (is_string($date))
+            $date = date($format, strtotime($date));
+        else
+            die('The given date was not an instance of DateTime, a UNIX timestamp or a date string.');
+
+        if ($this->version == Feed::ATOM)
+            $this->setChannelElement('updated', $date);
+        else
+            $this->setChannelElement('lastBuildDate', $date);
+
+        return $this;
+    }
+
+    /**
+    * Set the 'description' channel element
+    *
+    * @access   public
+    * @param    string  value of 'description' channel tag
+    * @return   self
+    */
+    public function setDescription($description)
+    {
+        if ($this->version != Feed::ATOM)
+            $this->setChannelElement('description', $description);
+
+        return $this;
+    }
+
+    /**
+    * Set the 'link' channel element
+    *
+    * @access   public
+    * @param    string  value of 'link' channel tag
+    * @return   self
+    */
+    public function setLink($link)
+    {
+        if ($this->version == Feed::ATOM)
+            $this->setChannelElement('link', '', array('href' => $link));
+        else
+            $this->setChannelElement('link', $link);
+
+        return $this;
+    }
+
+    /**
+    * Set custom 'link' channel elements.
+    *
+    * In ATOM feeds, only one link with alternate relation and the same combination of
+    * type and hreflang values.
+    *
+    * @access   public
+    * @param    string  URI of this link
+    * @param    string  relation type of the resource
+    * @param    string  MIME type of the target resource
+    * @param    string  language of the resource
+    * @param    string  human-readable information about the resource
+    * @param    int     length of the resource in bytes
+    * @link     https://www.iana.org/assignments/link-relations/link-relations.xml
+    * @link     https://tools.ietf.org/html/rfc4287#section-4.2.7
+    * @return   self
+    */
+    public function setAtomLink($href, $rel = null, $type = null, $hreflang = null, $title = null, $length = null)
+    {
+        $data = array('href' => $href);
+
+        if ($rel != null) {
+            if (!is_string($rel) || empty($rel))
+                die('rel parameter must be a string and a valid relation identifier.');
+
+            $data['rel'] = $rel;
+        }
+        if ($type != null) {
+            // Regex used from RFC 4287, page 41
+            if (!is_string($type) || preg_match('/.+\/.+/', $type) != 1)
+                die('type parameter must be a string and a MIME type.');
+
+            $data['type'] = $type;
+        }
+        if ($hreflang != null) {
+            // Regex used from RFC 4287, page 41
+            if (!is_string($hreflang) || preg_match('/[A-Za-z]{1,8}(-[A-Za-z0-9]{1,8})*/', $hreflang) != 1)
+                die('hreflang parameter must be a string and a valid language code.');
+
+            $data['hreflang'] = $hreflang;
+        }
+        if ($title != null) {
+            if (!is_string($title) || empty($title))
+                die('title parameter must be a string and not empty.');
+
+            $data['title'] = $title;
+        }
+        if ($length != null) {
+            if (!is_int($length) || $length < 0)
+                die('length parameter must be a positive integer.');
+
+            $data['length'] = (string) $length;
+        }
+
+        // ATOM spec. has some restrictions on atom:link usage
+        // See RFC 4287, page 12 (4.1.1)
+        if ($this->version == Feed::ATOM) {
+            foreach ($this->channels as $key => $value) {
+                if ($key != 'atom:link')
+                    continue;
+
+                // $value is an array , so check every element
+                foreach ($value as $linkItem) {
+                    // Only one link with relation alternate and same hreflang & type is allowed.
+                    if (@$linkItem['rel'] == 'alternate' && @$linkItem['hreflang'] == $hreflang && @$linkItem['type'] == $type)
+                        die('The feed must not contain more than one link element with a relation of "alternate"'
+                        . ' that has the same combination of type and hreflang attribute values.');
+                }
+            }
+        }
+
+        return $this->setChannelElement('atom:link', '', $data, true);
+    }
+
+    /**
+    * Set an 'atom:link' channel element with relation=self attribute.
+    * Needs the full URL to this feed.
+    *
+    * @link     http://www.rssboard.org/rss-profile#namespace-elements-atom-link
+    * @access   public
+    * @param    string  URL to this feed
+    * @return   self
+    */
+    public function setSelfLink($url)
+    {
+        return $this->setAtomLink($url, 'self', $this->getMIMEType());
+    }
+
+    /**
+    * Set the 'image' channel element
+    *
+    * @access   public
+    * @param    string  title of image
+    * @param    string  link url of the image
+    * @param    string  path url of the image
+    * @return   self
+    */
+    public function setImage($title, $link, $url)
+    {
+        return $this->setChannelElement('image', array('title'=>$title, 'link'=>$link, 'url'=>$url));
+    }
+
+    /**
+    * Set the 'about' channel element. Only for RSS 1.0
+    *
+    * @access   public
+    * @param    string  value of 'about' channel tag
+    * @return   self
+    */
+    public function setChannelAbout($url)
+    {
+        $this->data['ChannelAbout'] = $url;
+
+        return $this;
+    }
+
+    /**
+    * Generate an UUID.
+    *
+    * The UUID is based on an MD5 hash. If no key is given, a unique ID as the input
+    * for the MD5 hash is generated.
+    *
+    * @author   Anis uddin Ahmad <admin@ajaxray.com>
+    * @param    string  optional key on which the UUID is generated
+    * @param    string  an optional prefix
+    * @return   string  the formated UUID
+    */
+    public static function uuid($key = null, $prefix = '')
+    {
+        $key = ($key == null) ? uniqid(rand()) : $key;
+        $chars = md5($key);
+        $uuid  = substr($chars,0,8) . '-';
+        $uuid .= substr($chars,8,4) . '-';
+        $uuid .= substr($chars,12,4) . '-';
+        $uuid .= substr($chars,16,4) . '-';
+        $uuid .= substr($chars,20,12);
+
+        return $prefix . $uuid;
+    }
+
+    /**
+    * Replace invalid xml utf-8 chars.
+    *
+    * See utf8_for_xml() function at
+    * http://www.phpwact.org/php/i18n/charsets#xml and
+    * http://www.w3.org/TR/REC-xml/#charsets
+    *
+    * @param    string
+    * @return   string
+    */
+    public static function utf8_for_xml($string)
+    {
+        return preg_replace('/[^\x{0009}\x{000a}\x{000d}\x{0020}-\x{D7FF}\x{E000}-\x{FFFD}]+/u', ' ', $string);
+    }
+    // End # public functions ----------------------------------------------
+
+    // Start # private functions ----------------------------------------------
+
+    /**
+    * Returns all used XML namespace prefixes in this instance.
+    * This includes all channel elements and feed items.
+    * Unfortunately some namespace prefixes are not included,
+    * because they are hardcoded, e.g. rdf.
+    *
+    * @access   private
+    * @return   array   Array with namespace prefix as value.
+    */
+    private function getNamespacePrefixes()
+    {
+        $prefixes = array();
+
+        // Get all tag names from channel elements...
+        $tags = array_keys($this->channels);
+
+        // ... and now all names from feed items
+        foreach ($this->items as $item)
+            $tags = array_merge($tags, array_keys($item->getElements()));
+
+        // Look for prefixes in those tag names
+        foreach ($tags as $tag) {
+            $elements = explode(':', $tag);
+
+            if (count($elements) != 2)
+                continue;
+
+            $prefixes[] = $elements[0];
+        }
+
+        return array_unique($prefixes);
+    }
+
+    /**
+    * Returns the XML header and root element, depending on the feed type.
+    *
+    * @access   private
+    * @return   string  The XML header of the feed.
+    */
+    private function makeHeader()
+    {
+        $out = '<?xml version="1.0" encoding="'.$this->encoding.'" ?>' . PHP_EOL;
+
+        $prefixes = $this->getNamespacePrefixes();
+        $attributes = array();
+        $tagName = '';
+        $defaultNamespace = '';
+
+        if ($this->version == Feed::RSS2) {
+            $tagName = 'rss';
+            $attributes['version'] = '2.0';
+        } elseif ($this->version == Feed::RSS1) {
+            $tagName = 'rdf:RDF';
+            $prefixes[] = 'rdf';
+            $defaultNamespace = $this->namespaces['rss1'];
+        } elseif ($this->version == Feed::ATOM) {
+            $tagName = 'feed';
+            $defaultNamespace = $this->namespaces['atom'];
+
+            // Ugly hack to remove the 'atom' value from the prefixes array.
+            $prefixes = array_flip($prefixes);
+            unset($prefixes['atom']);
+            $prefixes = array_flip($prefixes);
+        }
+
+        // Iterate through every namespace prefix and add it to the element attributes.
+        foreach ($prefixes as $prefix) {
+            if (!isset($this->namespaces[$prefix]))
+                die('Unknown XML namespace prefix: \'' . $prefix . '\'. Use the addNamespace method to add support for this prefix.');
+            else
+                $attributes['xmlns:' . $prefix] = $this->namespaces[$prefix];
+        }
+
+        // Include default namepsace, if required
+        if (!empty($defaultNamespace))
+            $attributes['xmlns'] = $defaultNamespace;
+
+        $out .= $this->makeNode($tagName, '', $attributes, true);
+
+        return $out;
+    }
+    
+    /**
+    * Closes the open tags at the end of file
+    *
+    * @access   private
+    * @return   string  The XML footer of the feed.
+    */
+    private function makeFooter()
+    {
+        if ($this->version == Feed::RSS2) {
+            return '</channel>' . PHP_EOL . '</rss>';
+        } elseif ($this->version == Feed::RSS1) {
+            return '</rdf:RDF>';
+        } elseif ($this->version == Feed::ATOM) {
+            return '</feed>';
+        }
+    }
+
+    /**
+    * Creates a single node in XML format
+    *
+    * @access   private
+    * @param    string  name of the tag
+    * @param    mixed   tag value as string or array of nested tags in 'tagName' => 'tagValue' format
+    * @param    array   Attributes (if any) in 'attrName' => 'attrValue' format
+    * @param    string  True if the end tag should be omitted. Defaults to false.
+    * @return   string  formatted xml tag
+    */
+    private function makeNode($tagName, $tagContent, $attributes = null, $omitEndTag = false)
+    {
+        $nodeText = '';
+        $attrText = '';
+
+        if (is_array($attributes) && count($attributes) > 0) {
+            foreach ($attributes as $key => $value) {
+                $value = self::utf8_for_xml($value);
+                $value = htmlspecialchars($value);
+                $attrText .= " $key=\"$value\"";
+            }
+        }
+
+        if (is_array($tagContent) && $this->version == Feed::RSS1) {
+            $attrText = ' rdf:parseType="Resource"';
+        }
+
+        $attrText .= (in_array($tagName, $this->CDATAEncoding) && $this->version == Feed::ATOM) ? ' type="html"' : '';
+        $nodeText .= "<{$tagName}{$attrText}>";
+        $nodeText .= (in_array($tagName, $this->CDATAEncoding)) ? '<![CDATA[' : '';
+
+        if (is_array($tagContent)) {
+            foreach ($tagContent as $key => $value) {
+                $nodeText .= $this->makeNode($key, $value);
+            }
+        } else {
+            $tagContent = self::utf8_for_xml($tagContent);
+            $nodeText .= (in_array($tagName, $this->CDATAEncoding)) ? $this->sanitizeCDATA($tagContent) : htmlspecialchars($tagContent);
+        }
+
+        $nodeText .= (in_array($tagName, $this->CDATAEncoding)) ? ']]>' : '';
+
+        if (!$omitEndTag)
+            $nodeText .= "</$tagName>";
+
+        $nodeText .= PHP_EOL;
+
+        return $nodeText;
+    }
+
+    /**
+    * Make the channels.
+    *
+    * @access   private
+    * @return   string  The feed header as XML containing all the feed metadata.
+    */
+    private function makeChannels()
+    {
+        $out = '';
+
+        //Start channel tag
+        switch ($this->version) {
+            case Feed::RSS2:
+                $out .= '<channel>' . PHP_EOL;
+                break;
+            case Feed::RSS1:
+                $out .= (isset($this->data['ChannelAbout']))? "<channel rdf:about=\"{$this->data['ChannelAbout']}\">" : "<channel rdf:about=\"{$this->channels['link']}\">";
+                break;
+        }
+
+        //Print Items of channel
+        foreach ($this->channels as $key => $value) {
+            // In ATOM feeds, strip all ATOM namespace prefixes from the tag name. They are not needed here,
+            // because the ATOM namespace name is set as default namespace.
+            if ($this->version == Feed::ATOM && strncmp($key, 'atom', 4) == 0) {
+                $key = substr($key, 5);
+            }
+            
+            // The channel element can occur multiple times, when the key 'content' is not in the array.
+            if (!isset($value['content'])) {
+                // If this is the case, iterate through the array with the multiple elements.
+                foreach ($value as $singleElement) {
+                    $out .= $this->makeNode($key, $singleElement['content'], $singleElement['attributes']);
+                }
+            } else {
+                $out .= $this->makeNode($key, $value['content'], $value['attributes']);
+            }
+        }
+
+        if ($this->version == Feed::RSS1) {
+            //RSS 1.0 have special tag <rdf:Seq> with channel
+            $out .= "<items>" . PHP_EOL . "<rdf:Seq>" . PHP_EOL;
+            foreach ($this->items as $item) {
+                $thisItems = $item->getElements();
+                $out .= "<rdf:li resource=\"{$thisItems['link']['content']}\"/>" . PHP_EOL;
+            }
+            $out .= "</rdf:Seq>" . PHP_EOL . "</items>" . PHP_EOL . "</channel>" . PHP_EOL;
+        } else if ($this->version == Feed::ATOM) {
+            // ATOM feeds have a unique feed ID. This is generated from the 'link' channel element.
+            $out .= $this->makeNode('id', Feed::uuid($this->channels['link']['attributes']['href'], 'urn:uuid:'));
+        }
+
+        return $out;
+    }
+
+    /**
+    * Prints formatted feed items
+    *
+    * @access   private
+    * @return   string  The XML of every feed item.
+    */
+    private function makeItems()
+    {
+        $out = '';
+
+        foreach ($this->items as $item) {
+            $thisItems = $item->getElements();
+
+            // the argument is printed as rdf:about attribute of item in rss 1.0
+            $out .= $this->startItem($thisItems['link']['content']);
+
+            foreach ($thisItems as $feedItem) {
+                $name = $feedItem['name'];
+
+                // Strip all ATOM namespace prefixes from tags when feed is an ATOM feed.
+                // Not needed here, because the ATOM namespace name is used as default namespace.
+                if ($this->version == Feed::ATOM && strncmp($name, 'atom', 4) == 0)
+                    $name = substr($name, 5);
+
+                $out .= $this->makeNode($name, $feedItem['content'], $feedItem['attributes']);
+            }
+            $out .= $this->endItem();
+        }
+
+        return $out;
+    }
+
+    /**
+    * Make the starting tag of channels
+    *
+    * @access   private
+    * @param    string  The vale of about tag which is used for RSS 1.0 only.
+    * @return   string  The starting XML tag of an feed item.
+    */
+    private function startItem($about = false)
+    {
+        $out = '';
+
+        if ($this->version == Feed::RSS2) {
+            $out .= '<item>' . PHP_EOL;
+        } elseif ($this->version == Feed::RSS1) {
+            if ($about) {
+                $out .= "<item rdf:about=\"$about\">" . PHP_EOL;
+            } else {
+                throw new \Exception("link element is not set - It's required for RSS 1.0 to be used as the about attribute of the item tag.");
+            }
+        } elseif ($this->version == Feed::ATOM) {
+            $out .= "<entry>" . PHP_EOL;
+        }
+
+        return $out;
+    }
+
+    /**
+    * Closes feed item tag
+    *
+    * @access   private
+    * @return   string  The ending XML tag of an feed item.
+    */
+    private function endItem()
+    {
+        if ($this->version == Feed::RSS2 || $this->version == Feed::RSS1) {
+            return '</item>' . PHP_EOL;
+        } elseif ($this->version == Feed::ATOM) {
+            return '</entry>' . PHP_EOL;
+        }
+    }
+
+    /**
+    * Sanitizes data which will be later on returned as CDATA in the feed.
+    *
+    * A "]]>" respectively "<![CDATA" in the data would break the CDATA in the
+    * XML, so the brackets are converted to a HTML entity.
+    *
+    * @access   private
+    * @param    string  Data to be sanitized
+    * @return   string  Sanitized data
+    */
+    private function sanitizeCDATA($text)
+    {
+        $text = str_replace("]]>", "]]&gt;", $text);
+        $text = str_replace("<![CDATA[", "&lt;![CDATA[", $text);
+
+        return $text;
+    }
+
+    // End # private functions ----------------------------------------------
+
+} // end of class Feed

--- a/libraries/FeedWriter/Item.php
+++ b/libraries/FeedWriter/Item.php
@@ -1,0 +1,374 @@
+<?php
+namespace FeedWriter;
+
+use \DateTime;
+
+/*
+ * Copyright (C) 2008 Anis uddin Ahmad <anisniit@gmail.com>
+ * Copyright (C) 2010-2013 Michael Bemmerl <mail@mx-server.de>
+ *
+ * This file is part of the "Universal Feed Writer" project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Universal Feed Writer
+ *
+ * Item class - Used as feed element in Feed class
+ *
+ * @package         UniversalFeedWriter
+ * @author          Anis uddin Ahmad <anisniit@gmail.com>
+ * @link            http://www.ajaxray.com/projects/rss
+ */
+class Item
+{
+    /**
+    * Collection of feed item elements
+    */
+    private $elements = array();
+
+    /**
+    * Contains the format of this feed.
+    */
+    private $version;
+
+    /**
+    * Is used as a suffix when multiple elements have the same name.
+    **/
+    private $_cpt = 0;
+
+    /**
+    * Constructor
+    *
+    * @param    constant  (RSS1/RSS2/ATOM) RSS2 is default.
+    */
+    public function __construct($version = Feed::RSS2)
+    {
+        $this->version = $version;
+    }
+
+    /**
+    * Return an unique number
+    *
+    * @access   private
+    * @return   int
+    **/
+    private function cpt()
+    {
+        return $this->_cpt++;
+    }
+
+    /**
+    * Add an element to elements array
+    *
+    * @access   public
+    * @param    string  The tag name of an element
+    * @param    string  The content of tag
+    * @param    array   Attributes (if any) in 'attrName' => 'attrValue' format
+    * @param    boolean Specifies if an already existing element is overwritten.
+    * @param    boolean Specifies if multiple elements of the same name are allowed.
+    * @return   self
+    */
+    public function addElement($elementName, $content, $attributes = null, $overwrite = FALSE, $allowMultiple = FALSE)
+    {
+        $key = $elementName;
+
+        // return if element already exists & if overwriting is disabled
+        // & if multiple elements are not allowed.
+        if (isset($this->elements[$elementName]) && !$overwrite) {
+            if (!$allowMultiple)
+                return;
+
+            $key .= '-' . $this->cpt();
+        }
+
+        $this->elements[$key]['name']       = $elementName;
+        $this->elements[$key]['content']    = $content;
+        $this->elements[$key]['attributes'] = $attributes;
+
+        return $this;
+    }
+
+    /**
+    * Set multiple feed elements from an array.
+    * Elements which have attributes cannot be added by this method
+    *
+    * @access   public
+    * @param    array   array of elements in 'tagName' => 'tagContent' format.
+    * @return   self
+    */
+    public function addElementArray($elementArray)
+    {
+        if (!is_array($elementArray))
+            return;
+
+        foreach ($elementArray as $elementName => $content) {
+            $this->addElement($elementName, $content);
+        }
+
+        return $this;
+    }
+
+    /**
+    * Return the collection of elements in this feed item
+    *
+    * @access   public
+    * @return   array   All elements of this item.
+    */
+    public function getElements()
+    {
+        return $this->elements;
+    }
+
+    /**
+    * Return the type of this feed item
+    *
+    * @access   public
+    * @return   string  The feed type, as defined in Feed.php
+    */
+    public function getVersion()
+    {
+        return $this->version;
+    }
+
+    // Wrapper functions ------------------------------------------------------
+
+    /**
+    * Set the 'description' element of feed item
+    *
+    * @access   public
+    * @param    string  The content of 'description' or 'summary' element
+    * @return   self
+    */
+    public function setDescription($description)
+    {
+        $tag = ($this->version == Feed::ATOM) ? 'summary' : 'description';
+
+        return $this->addElement($tag, $description);
+    }
+
+    /**
+     * Set the 'content' element of the feed item
+     * For ATOM feeds only
+     *
+     * @access  public
+     * @param   string  Content for the item (i.e., the body of a blog post).
+     * @return  self
+     */
+    public function setContent($content)
+    {
+        if ($this->version != Feed::ATOM)
+            die('The content element is supported in ATOM feeds only.');
+
+        return $this->addElement('content', $content, array('type' => 'html'));
+    }
+
+    /**
+    * Set the 'title' element of feed item
+    *
+    * @access   public
+    * @param    string  The content of 'title' element
+    * @return   self
+    */
+    public function setTitle($title)
+    {
+        return $this->addElement('title', $title);
+    }
+
+    /**
+    * Set the 'date' element of the feed item.
+    *
+    * The value of the date parameter can be either an instance of the
+    * DateTime class, an integer containing a UNIX timestamp or a string
+    * which is parseable by PHP's 'strtotime' function.
+    *
+    * @access   public
+    * @param    DateTime|int|string  Date which should be used.
+    * @return   self
+    */
+    public function setDate($date)
+    {
+        if (!is_numeric($date)) {
+            if ($date instanceof DateTime)
+                $date = $date->getTimestamp();
+            else {
+                $date = strtotime($date);
+
+                if ($date === FALSE)
+                    die('The given date string was not parseable.');
+            }
+        } elseif ($date < 0)
+            die('The given date is not an UNIX timestamp.');
+
+        if ($this->version == Feed::ATOM) {
+            $tag    = 'updated';
+            $value  = date(\DATE_ATOM, $date);
+        } elseif ($this->version == Feed::RSS2) {
+            $tag    = 'pubDate';
+            $value  = date(\DATE_RSS, $date);
+        } else {
+            $tag    = 'dc:date';
+            $value  = date("Y-m-d", $date);
+        }
+
+        return $this->addElement($tag, $value);
+    }
+
+    /**
+    * Set the 'link' element of feed item
+    *
+    * @access   public
+    * @param    string  The content of 'link' element
+    * @return   void
+    */
+    public function setLink($link)
+    {
+        if ($this->version == Feed::RSS2 || $this->version == Feed::RSS1) {
+            $this->addElement('link', $link);
+        } else {
+            $this->addElement('link','',array('href'=>$link));
+            $this->addElement('id', Feed::uuid($link,'urn:uuid:'));
+        }
+
+        return $this;
+    }
+
+    /**
+    * Attach a external media to the feed item.
+    * Not supported in RSS 1.0 feeds.
+    *
+    * See RFC 4288 for syntactical correct MIME types.
+    *
+    * Note that you should avoid the use of more than one enclosure in one item,
+    * since some RSS aggregators don't support it.
+    *
+    * @access   public
+    * @param    string  The URL of the media.
+    * @param    integer The length of the media.
+    * @param    string  The MIME type attribute of the media.
+    * @param    boolean Specifies, if multiple enclosures are allowed
+    * @return   self
+    * @link     https://tools.ietf.org/html/rfc4288
+    */
+    public function addEnclosure($url, $length, $type, $multiple = TRUE)
+    {
+        if ($this->version == Feed::RSS1)
+            die('Media attachment is not supported in RSS1 feeds.');
+
+        // the length parameter should be set to 0 if it can't be determined
+        // see http://www.rssboard.org/rss-profile#element-channel-item-enclosure
+        if (!is_numeric($length) || $length < 0)
+            die('The length parameter must be an integer and greater or equals to zero.');
+
+        // Regex used from RFC 4287, page 41
+        if (!is_string($type) || preg_match('/.+\/.+/', $type) != 1)
+            die('type parameter must be a string and a MIME type.');
+
+        $attributes = array('length' => $length, 'type' => $type);
+
+        if ($this->version == Feed::RSS2) {
+            $attributes['url'] = $url;
+            $this->addElement('enclosure', '', $attributes, FALSE, $multiple);
+        } else {
+            $attributes['href'] = $url;
+            $attributes['rel'] = 'enclosure';
+            $this->addElement('atom:link', '', $attributes, FALSE, $multiple);
+        }
+
+        return $this;
+    }
+
+    /**
+    * Alias of addEnclosure, for backward compatibility. Using only this
+    * method ensures that the 'enclosure' element will be present only once.
+    *
+    * @access   public
+    * @param    string  The URL of the media.
+    * @param    integer The length of the media.
+    * @param    string  The MIME type attribute of the media.
+    * @return   self
+    * @link     https://tools.ietf.org/html/rfc4288
+    * @deprecated Use the addEnclosure method instead.
+    *
+    **/
+    public function setEnclosure($url, $length, $type)
+    {
+        return $this->addEnclosure($url, $length, $type, false);
+    }
+
+    /**
+    * Set the 'author' element of feed item.
+    * Not supported in RSS 1.0 feeds.
+    *
+    * @access   public
+    * @param    string  The author of this item
+    * @param    string  Optional email address of the author
+    * @param    string  Optional URI related to the author
+    * @return   self
+    */
+    public function setAuthor($author, $email = null, $uri = null)
+    {
+        switch ($this->version) {
+            case Feed::RSS1: die('The author element is not supported in RSS1 feeds.');
+                break;
+            case Feed::RSS2:
+                if ($email != null)
+                    $author = $email . ' (' . $author . ')';
+
+                $this->addElement('author', $author);
+                break;
+            case Feed::ATOM:
+                $elements = array('name' => $author);
+
+                // Regex from RFC 4287 page 41
+                if ($email != null && preg_match('/.+@.+/', $email) == 1)
+                    $elements['email'] = $email;
+
+                if ($uri != null)
+                    $elements['uri'] = $uri;
+
+                $this->addElement('author', $elements);
+                break;
+        }
+
+        return $this;
+    }
+
+    /**
+    * Set the unique identifier of the feed item
+    *
+    * @access   public
+    * @param    string  The unique identifier of this item
+    * @param    boolean The value of the 'isPermaLink' attribute in RSS 2 feeds.
+    * @return   self
+    */
+    public function setId($id, $permaLink = false)
+    {
+        if ($this->version == Feed::RSS2) {
+            if (!is_bool($permaLink))
+                die('The permaLink parameter must be boolean.');
+
+            $permaLink = $permaLink ? 'true' : 'false';
+
+            $this->addElement('guid', $id, array('isPermaLink' => $permaLink));
+        } elseif ($this->version == Feed::ATOM) {
+            $this->addElement('id', Feed::uuid($id,'urn:uuid:'), NULL, TRUE);
+        } else
+            die('A unique ID is not supported in RSS1 feeds.');
+
+        return $this;
+    }
+
+ } // end of class Item

--- a/libraries/FeedWriter/README
+++ b/libraries/FeedWriter/README
@@ -1,0 +1,45 @@
+This package can be used to generate feeds in either RSS 1.0, RSS 2.0 or ATOM
+formats.
+
+There are three main classes that abstract the feed information and another to
+encapsulate the feed items information.
+
+Applications can create feed writer object, several feed item objects, set
+several types of properties of either feeds and feed items, and add items to
+the feed.
+
+Once a feed is fully composed with its items, the feed writer class can generate
+the necessary XML structure to describe the feed in the RSS or ATOM formats.
+The feed is generated as part of the current feed output.
+
+
+Requirements
+============
+
+PHP >= 5.3
+
+If you don't have 5.3 available on your system, there's a version supporting
+PHP >= 5.0 in the "legacy-php-5.0" branch.
+
+
+Documentation
+=============
+
+The documentation can be found in the "gh-pages" branch or on GitHub Pages:
+http://mibe.github.io/FeedWriter/
+
+
+Authors
+=======
+(in chronological order)
+
+Anis uddin Ahmad
+Michael Bemmerl
+Phil Freo
+Paul Ferrett
+Brennen Bearnes
+Michael Robinson
+Baptiste Fontaine
+Kristián Valentín
+Brandtley McMinn
+Julian Bogdani

--- a/libraries/FeedWriter/RSS1.php
+++ b/libraries/FeedWriter/RSS1.php
@@ -1,0 +1,37 @@
+<?php
+namespace FeedWriter;
+
+/*
+ * Copyright (C) 2012 Michael Bemmerl <mail@mx-server.de>
+ *
+ * This file is part of the "Universal Feed Writer" project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Wrapper for creating RSS1 feeds
+ *
+ * @package     UniversalFeedWriter
+ */
+class RSS1 extends Feed
+{
+    /**
+    * {@inheritdoc}
+    */
+    public function __construct()
+    {
+        parent::__construct(Feed::RSS1);
+    }
+}

--- a/libraries/FeedWriter/RSS2.php
+++ b/libraries/FeedWriter/RSS2.php
@@ -1,0 +1,37 @@
+<?php
+namespace FeedWriter;
+
+/*
+ * Copyright (C) 2012 Michael Bemmerl <mail@mx-server.de>
+ *
+ * This file is part of the "Universal Feed Writer" project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Wrapper for creating RSS2 feeds
+ *
+ * @package     UniversalFeedWriter
+ */
+class RSS2 extends Feed
+{
+    /**
+    * {@inheritdoc}
+    */
+    public function __construct()
+    {
+        parent::__construct(Feed::RSS2);
+    }
+}

--- a/libraries/FeedWriter/composer.json
+++ b/libraries/FeedWriter/composer.json
@@ -1,0 +1,60 @@
+{
+    "name": "mibe/feedwriter",
+    "description": "Generate feeds in either RSS 1.0, RSS 2.0 or ATOM formats",
+    "keywords": ["RSS", "ATOM", "feed"],
+    "homepage": "https://github.com/mibe/FeedWriter",
+    "type": "library",
+    "license": "GPL-3.0",
+    "authors": [
+        {
+            "name": "Anis uddin Ahmad"
+        },
+        {
+            "name": "Michael Bemmerl",
+            "email": "mail@mx-server.de"
+        },
+        {
+            "name": "Phil Freo"
+        },
+        {
+            "name": "Paul Ferrett"
+        },
+        {
+            "name": "Brennen Bearnes"
+        },
+        {
+            "name": "Michael Robinson",
+            "email": "mike@pagesofinterest.net"
+        },
+        {
+            "name": "Baptiste Fontaine"
+        },
+        {
+            "name": "Kristián Valentín"
+        },
+        {
+            "name": "Brandtley McMinn"
+        },
+        {
+            "name": "Julian Bogdani"
+        }
+    ],
+    "minimum-stability": "dev",
+    "autoload": {
+        "classmap": [
+            "ATOM.php",
+            "Feed.php",
+            "Item.php",
+            "RSS1.php",
+            "RSS2.php"
+        ]
+    },
+    "require" : {
+        "php": ">=5.3.0"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        }
+    }
+}

--- a/libraries/FeedWriter/examples/example_atom.php
+++ b/libraries/FeedWriter/examples/example_atom.php
@@ -1,0 +1,71 @@
+<?php
+
+// You should use an autoloader instead of including the files directly.
+// This is done here only to make the examples work out of the box.
+include '../Item.php';
+include '../Feed.php';
+include '../ATOM.php';
+
+date_default_timezone_set('UTC');
+
+use \FeedWriter\ATOM;
+
+/*
+ * Copyright (C) 2008 Anis uddin Ahmad <anisniit@gmail.com>
+ *
+ * This file is part of the "Universal Feed Writer" project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// IMPORTANT : No need to add id for feed or channel. It will be automatically created from link.
+
+//Creating an instance of ATOM class.
+$TestFeed = new ATOM;
+
+//Setting the channel elements
+//Use wrapper functions for common elements
+$TestFeed->setTitle('Testing the RSS writer class');
+$TestFeed->setLink('http://www.ajaxray.com/rss2/channel/about');
+$TestFeed->setDate(new DateTime());
+
+//For other channel elements, use setChannelElement() function
+$TestFeed->setChannelElement('author', array('name'=>'Anis uddin Ahmad'));
+
+//You can add additional link elements, e.g. to a PubSubHubbub server with custom relations.
+$TestFeed->setSelfLink('http://example.com/myfeed');
+$TestFeed->setAtomLink('http://pubsubhubbub.appspot.com', 'hub');
+
+//Adding a feed. Generally this portion will be in a loop and add all feeds.
+
+//Create an empty Item
+$newItem = $TestFeed->createNewItem();
+
+//Add elements to the feed item
+//Use wrapper functions to add common feed elements
+$newItem->setTitle('The first feed');
+$newItem->setLink('http://www.yahoo.com');
+$newItem->setDate(time());
+$newItem->setAuthor('Anis uddin Ahmad', 'anis@example.invalid');
+$newItem->setEnclosure('http://upload.wikimedia.org/wikipedia/commons/4/49/En-us-hello-1.ogg', 11779, 'audio/ogg');
+
+//Internally changed to "summary" tag for ATOM feed
+$newItem->setDescription('This is a test of adding CDATA encoded description by the php <b>Universal Feed Writer</b> class');
+$newItem->setContent('<h1>hi.</h1> <p>This is the content for the entry.</p>');
+
+//Now add the feed item
+$TestFeed->addItem($newItem);
+
+//OK. Everything is done. Now generate the feed.
+$TestFeed->printFeed();

--- a/libraries/FeedWriter/examples/example_minimum.php
+++ b/libraries/FeedWriter/examples/example_minimum.php
@@ -1,0 +1,64 @@
+<?php
+
+// You should use an autoloader instead of including the files directly.
+// This is done here only to make the examples work out of the box.
+include '../Item.php';
+include '../Feed.php';
+include '../RSS2.php';
+
+date_default_timezone_set('UTC');
+
+use \FeedWriter\RSS2;
+
+/*
+ * Copyright (C) 2008 Anis uddin Ahmad <anisniit@gmail.com>
+ *
+ * This file is part of the "Universal Feed Writer" project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//Creating an instance of RSS2 class.
+$TestFeed = new RSS2;
+
+//Setting the channel elements
+//Use wrapper functions for common channel elements
+$TestFeed->setTitle('Testing & Checking the RSS writer class');
+$TestFeed->setLink('http://www.ajaxray.com/projects/rss');
+$TestFeed->setDescription('This is a test of creating a RSS 2.0 feed Universal Feed Writer');
+
+//Image title and link must match with the 'title' and 'link' channel elements for valid RSS 2.0
+$TestFeed->setImage('Testing & Checking the RSS writer class','http://www.ajaxray.com/projects/rss','http://www.rightbrainsolution.com/_resources/img/logo.png');
+
+//Let's add some feed items: Create two empty Item instances
+$itemOne = $TestFeed->createNewItem();
+$itemTwo = $TestFeed->createNewItem();
+
+//Add item details
+$itemOne->setTitle('The title of the first entry.');
+$itemOne->setLink('http://www.google.de');
+$itemOne->setDate(time());
+$itemOne->setDescription('And here\'s the description of the entry.');
+
+$itemTwo->setTitle('Lorem ipsum');
+$itemTwo->setLink('http://www.example.com');
+$itemTwo->setDate(1234567890);
+$itemTwo->setDescription('Lorem ipsum dolor sit amet, consectetur, adipisci velit');
+
+//Now add the feed item
+$TestFeed->addItem($itemOne);
+$TestFeed->addItem($itemTwo);
+
+//OK. Everything is done. Now generate the feed.
+$TestFeed->printFeed();

--- a/libraries/FeedWriter/examples/example_rss1.php
+++ b/libraries/FeedWriter/examples/example_rss1.php
@@ -1,0 +1,70 @@
+<?php
+
+// You should use an autoloader instead of including the files directly.
+// This is done here only to make the examples work out of the box.
+include '../Item.php';
+include '../Feed.php';
+include '../RSS1.php';
+
+date_default_timezone_set('UTC');
+
+use \FeedWriter\RSS1;
+
+/*
+ * Copyright (C) 2008 Anis uddin Ahmad <anisniit@gmail.com>
+ *
+ * This file is part of the "Universal Feed Writer" project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//Creating an instance of RSS1 class.
+$TestFeed = new RSS1;
+
+//Setting the channel elements
+//Use wrapper functions for common elements
+//For other optional channel elements, use setChannelElement() function
+$TestFeed->setTitle('Testing the RSS writer class');
+$TestFeed->setLink('http://www.ajaxray.com/rss2/channel/about');
+$TestFeed->setDescription('This is test of creating a RSS 1.0 feed by Universal Feed Writer');
+
+//It's important for RSS 1.0
+$TestFeed->setChannelAbout('http://www.ajaxray.com/rss2/channel/about');
+
+//Adding a feed. Generally this portion will be in a loop and add all feeds.
+
+//Create an empty FeedItem
+$newItem = $TestFeed->createNewItem();
+
+//Add elements to the feed item
+//Use wrapper functions to add common feed elements
+$newItem->setTitle('The first feed');
+$newItem->setLink('http://www.yahoo.com');
+//The parameter is a timestamp for setDate() function
+$newItem->setDate(time());
+$newItem->setDescription('This is test of adding CDATA encoded description by the php <b>Universal Feed Writer</b> class');
+//Use core addElement() function for other supported optional elements
+$newItem->addElement('dc:subject', 'Nothing but test');
+
+//Now add the feed item
+$TestFeed->addItem($newItem);
+
+//Adding multiple elements from array
+//Elements which have an attribute cannot be added by this way
+$newItem = $TestFeed->createNewItem();
+$newItem->addElementArray(array('title'=>'The 2nd feed', 'link'=>'http://www.google.com', 'description'=>'This is a test of the FeedWriter class'));
+$TestFeed->addItem($newItem);
+
+//OK. Everything is done. Now generate the feed.
+$TestFeed->printFeed();

--- a/libraries/FeedWriter/examples/example_rss2.php
+++ b/libraries/FeedWriter/examples/example_rss2.php
@@ -1,0 +1,119 @@
+<?php
+
+// You should use an autoloader instead of including the files directly.
+// This is done here only to make the examples work out of the box.
+include '../Item.php';
+include '../Feed.php';
+include '../RSS2.php';
+
+date_default_timezone_set('UTC');
+
+use \FeedWriter\RSS2;
+
+/**
+ * Copyright (C) 2008 Anis uddin Ahmad <anisniit@gmail.com>
+ * Copyright (C) 2013 Michael Bemmerl <mail@mx-server.de>
+ *
+ * This file is part of the "Universal Feed Writer" project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Creating an instance of RSS2 class.
+$TestFeed = new RSS2;
+
+// Setting some basic channel elements. These three elements are mandatory.
+$TestFeed->setTitle('Testing & Checking the Feed Writer project');
+$TestFeed->setLink('https://github.com/mibe/FeedWriter');
+$TestFeed->setDescription('This is just an example how to use the Feed Writer project in your code.');
+
+// Image title and link must match with the 'title' and 'link' channel elements for RSS 2.0,
+// which were set above.
+$TestFeed->setImage('Testing & Checking the Feed Writer project', 'https://github.com/mibe/FeedWriter', 'https://upload.wikimedia.org/wikipedia/commons/thumb/d/d9/Rss-feed.svg/256px-Rss-feed.svg.png');
+
+// Use core setChannelElement() function for other optional channel elements.
+// See http://www.rssboard.org/rss-specification#optionalChannelElements
+// for other optional channel elements. Here the language code for American English and
+$TestFeed->setChannelElement('language', 'en-US');
+
+// The date when this feed was lastly updated. The publication date is also set.
+$TestFeed->setDate(date(DATE_RSS, time()));
+$TestFeed->setChannelElement('pubDate', date(\DATE_RSS, strtotime('2013-04-06')));
+
+// You can add additional link elements, e.g. to a PubSubHubbub server with custom relations.
+// It's recommended to provide a backlink to the feed URL.
+$TestFeed->setSelfLink('http://example.com/myfeed');
+$TestFeed->setAtomLink('http://pubsubhubbub.appspot.com', 'hub');
+
+// You can add more XML namespaces for more custom channel elements which are not defined
+// in the RSS 2 specification. Here the 'creativeCommons' element is used. There are much more
+// available. Have a look at this list: http://feedvalidator.org/docs/howto/declare_namespaces.html
+$TestFeed->addNamespace('creativeCommons', 'http://backend.userland.com/creativeCommonsRssModule');
+$TestFeed->setChannelElement('creativeCommons:license', 'http://www.creativecommons.org/licenses/by/1.0');
+
+// If you want you can also add a line to publicly announce that you used
+// this fine piece of software to generate the feed. ;-)
+$TestFeed->addGenerator();
+
+// Here we are done setting up the feed. What's next is adding some feed items.
+
+// Create a new feed item.
+$newItem = $TestFeed->createNewItem();
+
+// Add basic elements to the feed item
+// These are again mandatory for a valid feed.
+$newItem->setTitle('Hello World!');
+$newItem->setLink('http://www.example.com');
+$newItem->setDescription('This is a test of adding a description by the <b>Feed Writer</b> classes. It\'s automatically CDATA encoded.');
+
+// The following method calls add some optional elements to the feed item.
+
+// Let's set the publication date of this item. You could also use a UNIX timestamp or
+// an instance of PHP's DateTime class.
+$newItem->setDate('2013-04-07 00:50:30');
+
+// You can also attach a media object to a feed item. You just need the URL, the byte length
+// and the MIME type of the media. Here's a quirk: The RSS2 spec says "The url must be an http url.".
+// Other schemes like ftp, https, etc. produce an error in feed validators.
+$newItem->setEnclosure('http://upload.wikimedia.org/wikipedia/commons/4/49/En-us-hello-1.ogg', 11779, 'audio/ogg');
+
+// If you want you can set the name (and email address) of the author of this feed item.
+$newItem->setAuthor('Anis uddin Ahmad', 'admin@ajaxray.com');
+
+// You can set a globally unique identifier. This can be a URL or any other string.
+// If you set permaLink to true, the identifier must be an URL. The default of the
+// permaLink parameter is false.
+$newItem->setId('http://example.com/URL/to/article', true);
+
+// Use the addElement() method for other optional elements.
+// This here will add the 'source' element. The second parameter is the value of the element
+// and the third is an array containing the element attributes.
+$newItem->addElement('source', 'Mike\'s page', array('url' => 'http://www.example.com'));
+
+// Now add the feed item to the main feed.
+$TestFeed->addItem($newItem);
+
+// Another method to add feeds items is by using an array which contains key-value pairs
+// of every item element. Elements which have attributes cannot be added by this way.
+$newItem = $TestFeed->createNewItem();
+$newItem->addElementArray(array('title'=> 'The 2nd item', 'link' => 'http://www.google.com', 'description' => 'Just another test.'));
+$TestFeed->addItem($newItem);
+
+// OK. Everything is done. Now generate the feed.
+// If you want to send the feed directly to the browser, use the printFeed() method.
+$myFeed = $TestFeed->generateFeed();
+
+// Do anything you want with the feed in $myFeed. Why not send it to the browser? ;-)
+// You could also save it to a file if you don't want to invoke your script every time.
+echo $myFeed;

--- a/modules/dimpact_rss_feed/dimpact_rss_feed.info
+++ b/modules/dimpact_rss_feed/dimpact_rss_feed.info
@@ -1,0 +1,5 @@
+name = Dimpact Rss Feed
+description = Generates a RSS feed based on tags and/or content types.
+package = Dimpact
+core = 7.x
+dependencies[] = entity

--- a/modules/dimpact_rss_feed/dimpact_rss_feed.module
+++ b/modules/dimpact_rss_feed/dimpact_rss_feed.module
@@ -1,0 +1,295 @@
+<?php
+
+/**
+ * Register the feedwriter library.
+ * @return array
+ */
+function dimpact_rss_feed_libraries_info() {
+  $libraries = array();
+  $libraries['FeedWriter'] = array(
+    'name' => 'FeedWriter',
+    'vendor url' => 'http://ajaxray.com/blog/php-universal-feed-generator-supports-rss-10-rss-20-and-atom',
+    'download url' => 'https://github.com/ajaxray/FeedWriter',
+    'version callback' => '_dimpact_rss_feed_feedwriter_version',
+    'files' => array(
+      'php' => array('RSS2.php', 'Feed.php', 'Item.php'),
+    ),
+  );
+
+  return $libraries;
+}
+
+/**
+ * Version callback for the feedwriter version.
+ * @return boolean
+ */
+function _dimpact_rss_feed_feedwriter_version() {
+  // Feedwriter has no versions, return TRUE.
+  return TRUE;
+}
+
+/**
+ * Implements hook_menu.
+ * Register url's with auto loader wildcard for taxonomy term.
+ * @return string
+ */
+function dimpact_rss_feed_menu() {
+  $items = array();
+
+  $items['rss/%dimpact_rss_feed_term'] = array(
+    'title' => 'Rss feed for content containing tag',
+    'description' => t('Rss feed for content containing tag'),
+    'page callback' => 'dimpact_rss_feed_all_content_with_tag_or_type',
+    'page arguments' => array(1),
+    'type' => MENU_CALLBACK,
+    'delivery callback' => 'dimpact_rss_feed_deliver_xml',
+    'access arguments' => array('access content'),
+  );
+
+  $items['rss/%dimpact_rss_feed_term/%'] = array(
+    'title' => 'Rss feed for content containing tag and specified by content type',
+    'description' => t('Rss feed for content containing tag and specified by content type'),
+    'page callback' => 'dimpact_rss_feed_content_with_tag_contenttype',
+    'page arguments' => array(1, 2),
+    'type' => MENU_CALLBACK,
+    'delivery callback' => 'dimpact_rss_feed_deliver_xml',
+    'access arguments' => array('access content'),
+  );
+
+  return $items;
+}
+
+/**
+ * Build feed with items based on rss tag.
+ * @param type $term
+ * @return string
+ */
+function dimpact_rss_feed_all_content_with_tag_or_type($term) {
+  if (_dimpact_rss_feed_library_installed() && $term) {
+    if (isset($term->vocabulary_machine_name)) {
+      // Term is taxonomy.
+      $feed = _dimpact_rss_feed_create_feed($term);
+      $feed = _dimpact_rss_feed_add_items($feed, $term);
+
+      return $feed;
+    }
+    elseif (isset($term->module)) {
+      // Term is content type.
+      $feed = _dimpact_rss_feed_create_feed(FALSE, $term->type);
+      $feed = _dimpact_rss_feed_add_items($feed, FALSE, $term->type);
+
+      return $feed;
+    }
+  }
+
+  return FALSE;
+}
+
+/**
+ * Build feed with items based on rss tag and content type.
+ * @param type $term
+ * @param type $arg2
+ * @return boolean
+ */
+function dimpact_rss_feed_content_with_tag_contenttype($term, $arg2) {
+  $content_type = check_plain($arg2);
+  if (_dimpact_rss_feed_library_installed() && $term && isset($content_type)) {
+    $feed = _dimpact_rss_feed_create_feed($term, $content_type);
+    $feed = _dimpact_rss_feed_add_items($feed, $term, $content_type);
+
+    return $feed;
+  }
+
+  return FALSE;
+}
+
+/**
+ * Customized delivery callback.
+ * Sets the xml content header and returns the output.
+ * @param type $page_callback_result
+ */
+function dimpact_rss_feed_deliver_xml($page_callback_result) {
+  // Print the output.
+  if (is_object($page_callback_result)) {
+    // Add xml output header.
+    drupal_add_http_header('Content-Type', 'text/xml; charset=utf-8');
+    print $page_callback_result->generateFeed();
+  }
+  else {
+    drupal_add_http_header('Content-Type', 'text/html; charset=utf-8');
+    print '<p>Error!</p>';
+  }
+}
+
+/**
+ * Load a taxonomy term by name and return it if found.
+ * @param type $term
+ * @return boolean
+ */
+function dimpact_rss_feed_term_load($term) {
+  $term = check_plain($term);
+  $term_object = taxonomy_get_term_by_name($term, 'tags');
+
+  if (!empty($term_object)) {
+    return reset($term_object);
+  }
+
+  $content_type = node_type_load($term);
+  if ($content_type && !empty($content_type)) {
+    return $content_type;
+  }
+
+  // No term could be found with the given term, log error.
+  watchdog('dimpact_rss_feed', 'No term could be loaded with name !name.', array('!name' => $term), WATCHDOG_NOTICE);
+  return FALSE;
+}
+
+/**
+ * Create the main feed output.
+ * @param type $term
+ */
+function _dimpact_rss_feed_create_feed($term = FALSE, $content_type = FALSE) {
+  // I need to include the classes manually sadly enough...libraries api doesn't support it.
+  $library_path = libraries_get_path('FeedWriter');
+  include($library_path . '/Item.php');
+  include($library_path . '/Feed.php');
+  include($library_path . '/RSS2.php');
+
+  global $base_url;
+
+  $feed = new FeedWriter\RSS2;
+
+  if ($term) {
+    // Build nice url to the term page.
+    $term_link = url('taxonomy/term/' . $term->tid, array('absolute' => TRUE));
+    $feed->setLink($term_link);
+  }
+
+  // Create the title for the feed.
+  if (!$content_type) {
+    $feed->setTitle($base_url . ', Tag: ' . $term->name);
+  }
+  elseif ($content_type && !$term) {
+    $feed->setTitle($base_url . ', Type: ' . $content_type);
+  }
+  else {
+    $feed->setTitle($base_url . ', Tag: ' . $term->name . ', Type: ' . $content_type);
+  }
+
+  // Description is not really a description, but a date.
+  $date = date(\DATE_RSS, time());
+  $feed->setDescription($date);
+
+  return $feed;
+}
+
+/**
+ * Add individual items to the feed.
+ * @global type $base_url
+ * @param type $feed
+ * @param type $term
+ * @param type $content_type
+ * @return type
+ */
+function _dimpact_rss_feed_add_items($feed, $term, $content_type = FALSE) {
+  $items = _dimpact_rss_feed_load_items($term, $content_type);
+
+  foreach ($items as $item) {
+    try {
+      global $base_url;
+      // Use the item with the entity api wrapper
+      $wrapper = entity_metadata_wrapper('node', $item);
+
+      // Create a new item for the feed.
+      $feed_item = $feed->createNewItem();
+
+      // Set properties of the node on the feed item.
+      $feed_item->setTitle($wrapper->label());
+      $feed_item->setLink(url('node/' . $wrapper->getIdentifier(), array('absolute' => TRUE)));
+
+      if (isset($wrapper->field_intro) && !empty($wrapper->field_intro->value())) {
+        $feed_item->setDescription($wrapper->field_intro->value());
+      }
+      elseif (isset($wrapper->body) && !empty($wrapper->body->value->value())) {
+        $summary = text_summary($wrapper->body->value->value(), NULL, 200);
+        $feed_item->setDescription($summary);
+      }
+      
+      $feed_item->setDate($wrapper->created->value());
+      $feed_item->setId($base_url . '/node/' . $wrapper->getIdentifier(), TRUE);
+
+      // Try to retrieve the attached image and prepend it to the content element.
+      $file = '';
+      if (isset($wrapper->field_image) && !empty($wrapper->field_image->value())) {
+        $file = file_load($wrapper->field_image->value()['fid']);
+        if (!empty($file)) {
+          $file_uri = file_create_url($file->uri);
+          $file = "<p><img src='$file_uri' /></p>";
+        }
+      }
+
+      $feed_item->addElement('content:encoded', $file . $wrapper->body->value->value());
+
+      // Add the newly created item to the feed.
+      $feed->addItem($feed_item);
+    }
+    catch (EntityMetadataWrapperException $ex) {
+      watchdog(
+          'dimpact_rss_feed', 'EntityMetadataWrapper exception in %function() <pre>@trace</pre>', array('%function' => __FUNCTION__, '@trace' => $ex->getTraceAsString()), WATCHDOG_ERROR
+      );
+    }
+  }
+
+  return $feed;
+}
+
+/**
+ * Find and load the nodes based on the requested term and content type.
+ * @param type $term
+ * @param type $content_type
+ * @return type
+ */
+function _dimpact_rss_feed_load_items($term, $content_type) {
+  // Build the query to use for retrieving the items.
+  $query = new EntityFieldQuery();
+  $query->entityCondition('entity_type', 'node')
+      ->propertyCondition('status', NODE_PUBLISHED)
+      ->propertyOrderBy('changed', 'DESC');
+
+  // Add term if provided.
+  if ($term) {
+    $query->fieldCondition('field_tags', 'tid', $term->tid);
+  }
+
+  // Add content type if provided.
+  if ($content_type) {
+    $query->entityCondition('bundle', $content_type);
+  }
+
+  // Execute the query.
+  $result = $query->execute();
+  $node_items = array();
+  if (isset($result['node'])) {
+    $node_items_nids = array_keys($result['node']);
+    $node_items = entity_load('node', $node_items_nids);
+  }
+
+  return $node_items;
+}
+
+/**
+ * Check if the feedwriter library is installed.
+ * @return boolean
+ */
+function _dimpact_rss_feed_library_installed() {
+  if (($library = libraries_detect('FeedWriter')) && !empty($library['installed'])) {
+    // The library is installed.
+    return TRUE;
+  }
+  else {
+    // Something went wrong.
+    watchdog('dimpact_rss_feed', 'Library not available: !error', array('!error' => print_r($library, TRUE), WATCHDOG_ERROR));
+    drupal_set_message(t('RSS library not available. Cannot generate feed.'), 'error');
+    return FALSE;
+  }
+}


### PR DESCRIPTION
Voor Enschede is een RSS feed gemaakt die content kan tonen op basis van (taxonomy) tag en/of contenttype. Bijvoorbeeld https://www.enschede.nl/rss/Enschede%20nieuws en https://www.enschede.nl/rss/Enschede%20nieuws/news.
