### PR TITLE
Add domain to custom list query for administrators

### DIFF
--- a/modules/custom_lists/custom_lists.module
+++ b/modules/custom_lists/custom_lists.module
@@ -297,6 +297,18 @@ function custom_lists_content_nodes($list, $items, $full_load = TRUE) {
     $query->join('taxonomy_index', 'ti', 'ti.nid = n.nid');
     $query->condition('ti.tid', $list['taxonomy']);
   }
+  if (user_access('bypass node access') || user_access('administer nodes')) {
+    /*
+     * Custom lists should show only content assigned to the current domain.
+     * For regular users this is fixed by domain access itself.
+     * Administrators see content from all domains because domain access does not enforce node viewing restrictions.
+     * Gemeente Zwolle asked this to be fixed for administrators as well, so domain needs to be enforced in the query.
+     */
+    global $_domain;
+    $domain_id = $_domain['domain_id'];
+    $query->innerJoin('domain_access', 'd', 'n.nid = d.nid');
+    $query->condition('d.gid', $domain_id, '=');
+  }
 
   // Custom filters for certain use cases.
   if (!empty($list['extra-filters']) && $list['extra-filters'] != '_none') {


### PR DESCRIPTION
Van de offerte:

> Content die via een slimme lijst gepubliceerd wordt, onttrekt zich aan de domeinscheiding. Binnen het geheel aan (sub)sites wordt één taxonomie (termenlijst) gebruikt. Met een trefwoord kan een slimme lijst worden gecreëerd. Wordt dit trefwoord op meerdere sites gebruikt, dan worden ook pagina’s van een andere subsite getoond, onafhankelijk van de toekenning aan het domein.
> 
> Hiervoor is inmiddels een oplossing gemaakt. Deze oplossing voldoet alleen nog niet volledig aan onze wensen. De admin/beheerder van de (sub)sites ziet namelijk nog steeds alles wanneer hij is ingelogd. Het verwachte gedrag zou moeten zijn dat je binnen zwolle.nl alles van zwolle.nl ziet, en binnen beelden.zwolle.nl zie je alles van beelden.zwolle.nl.
> 
> Gewenste oplossing: Slimme lijsten tonen enkel nodes die binnen dat domein gepubliceerd zijn ook indien de beheerder is ingelogd
